### PR TITLE
Embed Discourse links in the error message box

### DIFF
--- a/streamlit_discourse/__init__.py
+++ b/streamlit_discourse/__init__.py
@@ -95,7 +95,7 @@ def _get_data(etype, str_exception, top, criteria, sortby, status):
 
     # TODO: Improve above search logic
 
-    # See: https://docs.discourse.org/#tag/Search    
+    # See: https://docs.discourse.org/#tag/Search
     if sortby in _ALLOWED_SORTS:
         query = query + f" order:{sortby}"
 
@@ -111,7 +111,7 @@ def _get_data(etype, str_exception, top, criteria, sortby, status):
 
     result = result.head(top)
 
-    return _display_result(result)
+    return result
 
 
 def _display_result(result):
@@ -159,7 +159,9 @@ def discourse(top=5, criteria="broad", sortby="relevance", status="any"):
         etype = type(e).__name__  # e.g. 'ValueError', 'TypeError'
         str_exception = e  # e.g. invalid literal for int() with base 10: 'foo'
 
-        _get_data(etype, str_exception, top, criteria, sortby, status)
+        discourse_links = _get_data(etype, str_exception, top, criteria, sortby, status)
+
+        _display_result(discourse_links)
 
         # If the code in the `with` block raises an exception,
         # re-raise it so that the user sees the error.

--- a/streamlit_discourse/__init__.py
+++ b/streamlit_discourse/__init__.py
@@ -122,6 +122,17 @@ def _display_result(result):
         st.markdown(topic_url)
 
 
+def _format_result(result):
+    links = []
+
+    for topic_id, title in result[["id", "title"]].values:
+        topic_url = _BASE_URL + "/t/" + str(topic_id)
+        topic_url = f"- [{title}]({topic_url})"
+        links.append(topic_url)
+
+    return "\n".join(links)
+
+
 @contextmanager
 def discourse(top=5, criteria="broad", sortby="relevance", status="any"):
     """Use in a `with` block to execute some code and display


### PR DESCRIPTION
This pull request embeds discourse links in a self-made error message box, which reproduces Streamlit's native exception box.
It also removes Streamlit's `exec()` traceback frame from error messages.